### PR TITLE
♻️ Užij argumentu místo globály

### DIFF
--- a/morfo_segmentace_manuální.py
+++ b/morfo_segmentace_manuální.py
@@ -116,7 +116,7 @@ def ulozeni_substituovaneho_textu(text):
 
 def porovnani_textu_se_slovnikem(text_mnozina, obsah_slovniku):
     # porovnání slov k segmentaci se slovy ve slovníku (zda už některé z nich ve slovníku nejsou segmentované)
-    vysledek_porovnani = list(text_mnozina - slova_ze_slovniku)
+    vysledek_porovnani = list(text_mnozina - obsah_slovniku)
     print(len(vysledek_porovnani)) # vypíše počet slov, které je třeba nasegmentovat (obvykle neradostné číslo)
 
     return vysledek_porovnani


### PR DESCRIPTION
Argument _obsah_slovniku_ funkce [_morfo_segmentace_manuální.porovnani_textu_se_slovnikem_](https://github.com/pelegrinova/morfo_segmentace/blob/5a5ce5a819bb84ffffe23d9ada39bce72cc51f53/morfo_segmentace_manu%C3%A1ln%C3%AD.py#L117) se nepoužíval. Místo něj se používala globální proměnná _slova_ze_slovniku_, jež se v jediném volání uvedené funkce předávala zbytečně jako argument.

Po této úpravě funkce nepoužívá žádné globální proměnné. Je tedy bez vedlejších účinků a také přímo testovatelná.