### PR TITLE
PEP 8: Odstraň mezery z konců řádků

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -25,9 +25,9 @@ for cislo in cisla:
             slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
         except KeyError:
             print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
-            pass   # 
+            pass   #
 
-    text_segmentovany_slouceny = " ".join(slova_k_segmentaci) 
+    text_segmentovany_slouceny = " ".join(slova_k_segmentaci)
 
     # uložení výsledku segmentace do souboru
     with open(f"vysledek_segmentace_stud_{cislo}.txt", mode="x" ,encoding="UTF-8") as soubor:

--- a/morfo_segmentace_manuální.py
+++ b/morfo_segmentace_manuální.py
@@ -34,7 +34,7 @@ def uprava_textu(text):
     text_na_slova_foneticky = []
     for slovo in text_na_slova: # pokud uniq slova, musí se tu přepsat ta proměnná text_na_slova_uniq
         slovo = slovo.replace("pouč", "po@uč")  # joojoo, tohle je prasárna a vím o tom; třeba vyřešit
-        slovo = slovo.replace("nauč", "na@uč")  
+        slovo = slovo.replace("nauč", "na@uč")
         slovo = slovo.replace("douč", "do@uč")
         slovo = slovo.replace("přeuč", "pře@uč")
         slovo = slovo.replace("přiuč", "při@uč")
@@ -124,7 +124,7 @@ def porovnani_textu_se_slovnikem(text_mnozina, obsah_slovniku):
 
 def segmentace_manualni(slova):
     # segmentace slova + vytváření slovníku
-    with open("můj_slovník.csv", "a", encoding="UTF-8") as csvfile: 
+    with open("můj_slovník.csv", "a", encoding="UTF-8") as csvfile:
         vysledek_segmentace = csv.writer(csvfile, delimiter=';', lineterminator='\n')
         for polozka in slova:
             zpracovane = input(f"{polozka}: ")

--- a/morfo_segmentace_výpočet_malu_tokens.py
+++ b/morfo_segmentace_výpočet_malu_tokens.py
@@ -18,7 +18,7 @@ for cislo in cisla:
 
     ## přípravné výpočty
     # výpočet délky konstruktu v konstituentech
-    delka_slov_v_morfech = [] 
+    delka_slov_v_morfech = []
     for slovo in segmentovany_text_tokens:
         delka_slova_v_morfech = slovo.count("-") + 1
         delka_slov_v_morfech.append(delka_slova_v_morfech)
@@ -54,7 +54,7 @@ for cislo in cisla:
     # slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
     slovnik_data_pro_mal = {}
     for klic in soucty_delek_x_morfovych_slov:
-        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic]) 
+        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
 
     print(dict(sorted(slovnik_data_pro_mal.items()))) # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
 
@@ -69,12 +69,12 @@ for cislo in cisla:
                 mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}") # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
                 vysledek.append(mezivysledek_carka)
         return vysledek
-        
+
     vysledek_mal = vypocet_mal(slovnik_data_pro_mal)
     print(vysledek_mal)
 
     # uložení výsledků do tabulky
-    with open(f"data_S_M_F_tokens_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile: 
+    with open(f"data_S_M_F_tokens_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile:
         vysledek_data = csv.writer(csvfile, delimiter=';',lineterminator='\n')
         vysledek_data.writerow(["construct", "frq", "mean of constituent"])
         for i in vysledek_mal:

--- a/morfo_segmentace_výpočet_malu_types.py
+++ b/morfo_segmentace_výpočet_malu_types.py
@@ -30,7 +30,7 @@ for cislo in cisla:
 
     ## přípravné výpočty
     # výpočet délky konstruktu v konstituentech
-    delka_slov_v_morfech = [] 
+    delka_slov_v_morfech = []
     for slovo in segmentovany_text_types:
         delka_slova_v_morfech = slovo.count("-") + 1
         delka_slov_v_morfech.append(delka_slova_v_morfech)
@@ -66,7 +66,7 @@ for cislo in cisla:
     # slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
     slovnik_data_pro_mal = {}
     for klic in soucty_delek_x_morfovych_slov:
-        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic]) 
+        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
 
     print(dict(sorted(slovnik_data_pro_mal.items()))) # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
 
@@ -81,13 +81,13 @@ for cislo in cisla:
                 mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}") # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
                 vysledek.append(mezivysledek_carka)
         return vysledek
-        
+
     vysledek_data = vypocet_mal(slovnik_data_pro_mal)
     print(vysledek_data)
     print(segmentovany_text_types)
 
     # uložení výsledků do tabulky
-    with open(f"data_S_M_F_types_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile: 
+    with open(f"data_S_M_F_types_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile:
         vysledek_mal = csv.writer(csvfile, delimiter=';',lineterminator='\n')
         vysledek_mal.writerow(["construct", "frq", "mean of constituent"])
         for i in vysledek_data:


### PR DESCRIPTION
Na koncích řádků by neměly být mezery. To platí i pro prázdné řádky, jež by měly být zcela prázdné. Viz [PEP 8#Other Recommendations](https://www.python.org/dev/peps/pep-0008/#other-recommendations).

Opravuje porušení W291 a W293. Viz seznam [porušení](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes).