### PR TITLE
PEP 8: Sluč prázdné řádky

### DIFF
--- a/morfo_segmentace_výpočet_malu_tokens.py
+++ b/morfo_segmentace_výpočet_malu_tokens.py
@@ -15,7 +15,6 @@ for cislo in cisla:
     with open(f"vysledek_segmentace_stud_{cislo}.txt", encoding="UTF-8") as soubor:
         segmentovany_text_tokens = soubor.read().strip().split(sep=" ")
 
-
     ## přípravné výpočty
     # výpočet délky konstruktu v konstituentech
     delka_slov_v_morfech = [] 


### PR DESCRIPTION
Oddělení kusů kódu prázdným řádkem by mělo zůstat pouze u jednoho takového prázdného řádku. Viz [PEP 8#Blank Lines](https://www.python.org/dev/peps/pep-0008/#blank-lines)

Opravuje porušení E303. Viz seznam [porušení](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes).