### PR TITLE
🗑️ Odstraň cykly procházející více souborů

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -12,24 +12,20 @@ with open("můj_slovník.csv", encoding="UTF-8") as soubor:
 
 slovnik = dict(polozky_ze_slovniku)
 
+# načtení textu/slov k segmentaci (a odstranění případné mezery na konci)
+with open("foneticky_přepsaný_stud.txt", encoding="UTF-8") as soubor:
+    slova_k_segmentaci = soubor.read().strip().split(sep=" ")
 
-cisla = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "slouč"]
+# autosegmentace
+for i in range(len(slova_k_segmentaci)):
+    try:
+        slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
+    except KeyError:
+        print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
+        pass   #
 
-for cislo in cisla:
-    # načtení textu/slov k segmentaci (a odstranění případné mezery na konci)
-    with open(f"foneticky_přepsaný_stud_{cislo}.txt", encoding="UTF-8") as soubor:
-        slova_k_segmentaci = soubor.read().strip().split(sep=" ")
+text_segmentovany_slouceny = " ".join(slova_k_segmentaci)
 
-    # autosegmentace
-    for i in range(len(slova_k_segmentaci)):
-        try:
-            slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
-        except KeyError:
-            print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
-            pass   #
-
-    text_segmentovany_slouceny = " ".join(slova_k_segmentaci)
-
-    # uložení výsledku segmentace do souboru
-    with open(f"vysledek_segmentace_stud_{cislo}.txt", mode="x", encoding="UTF-8") as soubor:
-        print(text_segmentovany_slouceny, file=soubor)
+# uložení výsledku segmentace do souboru
+with open("vysledek_segmentace_stud.txt", mode="x", encoding="UTF-8") as soubor:
+    print(text_segmentovany_slouceny, file=soubor)

--- a/morfo_segmentace_výpočet_malu_tokens.py
+++ b/morfo_segmentace_výpočet_malu_tokens.py
@@ -7,74 +7,74 @@ from locale import setlocale
 # nastavení "lokality"
 setlocale(LC_NUMERIC, "cs_CZ.UTF-8")
 
-cisla = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "slouč"]
+# načtení segmentovaného textu
+with open("vysledek_segmentace_stud.txt", encoding="UTF-8") as soubor:
+    segmentovany_text_tokens = soubor.read().strip().split(sep=" ")
 
-for cislo in cisla:
+# přípravné výpočty
+# výpočet délky konstruktu v konstituentech
+delka_slov_v_morfech = []
+for slovo in segmentovany_text_tokens:
+    delka_slova_v_morfech = slovo.count("-") + 1
+    delka_slov_v_morfech.append(delka_slova_v_morfech)
 
-    # načtení segmentovaného textu
-    with open(f"vysledek_segmentace_stud_{cislo}.txt", encoding="UTF-8") as soubor:
-        segmentovany_text_tokens = soubor.read().strip().split(sep=" ")
+# výpočet délky konstruktu v subkonstituentech
+nesegmentovany_text = []
+for segmentovane_slovo in segmentovany_text_tokens:
+    hole_slovo = segmentovane_slovo.replace("-", "")
+    nesegmentovany_text.append(hole_slovo)
 
-    # přípravné výpočty
-    # výpočet délky konstruktu v konstituentech
-    delka_slov_v_morfech = []
-    for slovo in segmentovany_text_tokens:
-        delka_slova_v_morfech = slovo.count("-") + 1
-        delka_slov_v_morfech.append(delka_slova_v_morfech)
+delka_slov_ve_fonemech = []
+for slovo in nesegmentovany_text:
+    delka_slova_ve_fonemech = len(slovo)
+    delka_slov_ve_fonemech.append(delka_slova_ve_fonemech)
 
-    # výpočet délky konstruktu v subkonstituentech
-    nesegmentovany_text = []
-    for segmentovane_slovo in segmentovany_text_tokens:
-        hole_slovo = segmentovane_slovo.replace("-", "")
-        nesegmentovany_text.append(hole_slovo)
 
-    delka_slov_ve_fonemech = []
-    for slovo in nesegmentovany_text:
-        delka_slova_ve_fonemech = len(slovo)
-        delka_slov_ve_fonemech.append(delka_slova_ve_fonemech)
+# počítadlo frekvencí
+def pocitadlo(soubor):
+    frekvence = Counter(soubor)
+    return frekvence
 
-    # počítadlo frekvencí
-    def pocitadlo(soubor):
-        frekvence = Counter(soubor)
-        return frekvence
 
-    # počet x-konstituentových konstruktů
-    frekvence_morfu = pocitadlo(delka_slov_v_morfech)
+# počet x-konstituentových konstruktů
+frekvence_morfu = pocitadlo(delka_slov_v_morfech)
 
-    # slovník: klíč = x-konstituentový konstrukt, hodnota = součet délek všech takových konstruktů (dvou-morfémové slovo, součet délek všech dvou-morfémových slov)
-    soucty_delek_x_morfovych_slov = {}
-    for i, klic in enumerate(delka_slov_v_morfech):
-        if klic not in soucty_delek_x_morfovych_slov:
-            soucty_delek_x_morfovych_slov[klic] = 0
-        soucty_delek_x_morfovych_slov[klic] += delka_slov_ve_fonemech[i]
+# slovník: klíč = x-konstituentový konstrukt, hodnota = součet délek všech takových konstruktů (dvou-morfémové slovo, součet délek všech dvou-morfémových slov)
+soucty_delek_x_morfovych_slov = {}
+for i, klic in enumerate(delka_slov_v_morfech):
+    if klic not in soucty_delek_x_morfovych_slov:
+        soucty_delek_x_morfovych_slov[klic] = 0
+    soucty_delek_x_morfovych_slov[klic] += delka_slov_ve_fonemech[i]
 
-    print(soucty_delek_x_morfovych_slov)
+print(soucty_delek_x_morfovych_slov)
 
-    # slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
-    slovnik_data_pro_mal = {}
-    for klic in soucty_delek_x_morfovych_slov:
-        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
+# slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
+slovnik_data_pro_mal = {}
+for klic in soucty_delek_x_morfovych_slov:
+    slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
 
-    print(dict(sorted(slovnik_data_pro_mal.items())))  # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
+print(dict(sorted(slovnik_data_pro_mal.items())))  # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
 
-    # funkce s výpočtem MALu
-    def vypocet_mal(data):
-        vysledek = []
-        for klic in sorted(data):  # tahá ze seřazeného seznamu klíčů, ale nic nepřepisuje !
-            if klic == 0:
-                pass
-            else:
-                prumer = round(Decimal(str(data[klic][0] / (data[klic][1] * klic))), 2)
-                mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}")  # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
-                vysledek.append(mezivysledek_carka)
-        return vysledek
 
-    vysledek_mal = vypocet_mal(slovnik_data_pro_mal)
-    print(vysledek_mal)
+# funkce s výpočtem MALu
+def vypocet_mal(data):
+    vysledek = []
+    for klic in sorted(data):  # tahá ze seřazeného seznamu klíčů, ale nic nepřepisuje !
+        if klic == 0:
+            pass
+        else:
+            prumer = round(Decimal(str(data[klic][0] / (data[klic][1] * klic))), 2)
+            mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}")  # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
+            vysledek.append(mezivysledek_carka)
+    return vysledek
 
-    # uložení výsledků do tabulky
-    with open(f"data_S_M_F_tokens_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile:
-        vysledek_data = csv.writer(csvfile, delimiter=';', lineterminator='\n')
-        vysledek_data.writerow(["construct", "frq", "mean of constituent"])
-        for i in vysledek_mal:
-            vysledek_data.writerow([i[0], i[1], i[2]])
+
+vysledek_mal = vypocet_mal(slovnik_data_pro_mal)
+print(vysledek_mal)
+
+# uložení výsledků do tabulky
+with open("data_S_M_F_tokens_stud.csv", "x", encoding="UTF-8") as csvfile:
+    vysledek_data = csv.writer(csvfile, delimiter=';', lineterminator='\n')
+    vysledek_data.writerow(["construct", "frq", "mean of constituent"])
+    for i in vysledek_mal:
+        vysledek_data.writerow([i[0], i[1], i[2]])

--- a/morfo_segmentace_výpočet_malu_types.py
+++ b/morfo_segmentace_výpočet_malu_types.py
@@ -7,88 +7,89 @@ from locale import setlocale
 # nastavení "lokality"
 setlocale(LC_NUMERIC, "cs_CZ.UTF-8")
 
+# načtení segmentovaného textu
+with open("vysledek_segmentace_stud.txt", encoding="UTF-8") as soubor:
+    segmentovany_text = soubor.read().strip().split(sep=" ")
 
-cisla = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "slouč"]
 
-for cislo in cisla:
+# převod textu v tokens na text v types
+def token_to_types(text):
+    text_types = []
 
-    # načtení segmentovaného textu
-    with open(f"vysledek_segmentace_stud_{cislo}.txt", encoding="UTF-8") as soubor:
-        segmentovany_text = soubor.read().strip().split(sep=" ")
+    for slovo in text:
+        if slovo not in text_types:
+            text_types.append(slovo)
 
-    # převod textu v tokens na text v types
-    def token_to_types(text):
-        text_types = []
+    return text_types
 
-        for slovo in text:
-            if slovo not in text_types:
-                text_types.append(slovo)
 
-        return text_types
+segmentovany_text_types = token_to_types(segmentovany_text)
 
-    segmentovany_text_types = token_to_types(segmentovany_text)
+# přípravné výpočty
+# výpočet délky konstruktu v konstituentech
+delka_slov_v_morfech = []
+for slovo in segmentovany_text_types:
+    delka_slova_v_morfech = slovo.count("-") + 1
+    delka_slov_v_morfech.append(delka_slova_v_morfech)
 
-    # přípravné výpočty
-    # výpočet délky konstruktu v konstituentech
-    delka_slov_v_morfech = []
-    for slovo in segmentovany_text_types:
-        delka_slova_v_morfech = slovo.count("-") + 1
-        delka_slov_v_morfech.append(delka_slova_v_morfech)
+# výpočet délky konstruktu v subkonstituentech
+nesegmentovany_text = []
+for segmentovane_slovo in segmentovany_text_types:
+    hole_slovo = segmentovane_slovo.replace("-", "")
+    nesegmentovany_text.append(hole_slovo)
 
-    # výpočet délky konstruktu v subkonstituentech
-    nesegmentovany_text = []
-    for segmentovane_slovo in segmentovany_text_types:
-        hole_slovo = segmentovane_slovo.replace("-", "")
-        nesegmentovany_text.append(hole_slovo)
+delka_slov_ve_fonemech = []
+for slovo in nesegmentovany_text:
+    delka_slova_ve_fonemech = len(slovo)
+    delka_slov_ve_fonemech.append(delka_slova_ve_fonemech)
 
-    delka_slov_ve_fonemech = []
-    for slovo in nesegmentovany_text:
-        delka_slova_ve_fonemech = len(slovo)
-        delka_slov_ve_fonemech.append(delka_slova_ve_fonemech)
 
-    # počítadlo frekvencí
-    def pocitadlo(soubor):
-        frekvence = Counter(soubor)
-        return frekvence
+# počítadlo frekvencí
+def pocitadlo(soubor):
+    frekvence = Counter(soubor)
+    return frekvence
 
-    # počet x-konstituentových konstruktů
-    frekvence_morfu = pocitadlo(delka_slov_v_morfech)
 
-    # slovník: klíč = x-konstituentový konstrukt, hodnota = součet délek všech takových konstruktů (dvou-morfémové slovo, součet délek všech dvou-morfémových slov)
-    soucty_delek_x_morfovych_slov = {}
-    for i, klic in enumerate(delka_slov_v_morfech):
-        if klic not in soucty_delek_x_morfovych_slov:
-            soucty_delek_x_morfovych_slov[klic] = 0
-        soucty_delek_x_morfovych_slov[klic] += delka_slov_ve_fonemech[i]
+# počet x-konstituentových konstruktů
+frekvence_morfu = pocitadlo(delka_slov_v_morfech)
 
-    print(soucty_delek_x_morfovych_slov)
+# slovník: klíč = x-konstituentový konstrukt, hodnota = součet délek všech takových konstruktů (dvou-morfémové slovo, součet délek všech dvou-morfémových slov)
+soucty_delek_x_morfovych_slov = {}
+for i, klic in enumerate(delka_slov_v_morfech):
+    if klic not in soucty_delek_x_morfovych_slov:
+        soucty_delek_x_morfovych_slov[klic] = 0
+    soucty_delek_x_morfovych_slov[klic] += delka_slov_ve_fonemech[i]
 
-    # slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
-    slovnik_data_pro_mal = {}
-    for klic in soucty_delek_x_morfovych_slov:
-        slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
+print(soucty_delek_x_morfovych_slov)
 
-    print(dict(sorted(slovnik_data_pro_mal.items())))  # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
+# slovník: klíč = x-konstituentový konstrukt, hodnota = (součet délek všech takových konstruktů, počet takových konstuktů)
+slovnik_data_pro_mal = {}
+for klic in soucty_delek_x_morfovych_slov:
+    slovnik_data_pro_mal[klic] = (soucty_delek_x_morfovych_slov[klic], frekvence_morfu[klic])
 
-    # funkce s výpočtem MALu
-    def vypocet_mal(data):
-        vysledek = []
-        for klic in sorted(data):  # tahá ze seřazeného seznamu klíčů, ale nic nepřepisuje !
-            if klic == 0:
-                pass
-            else:
-                prumer = round(Decimal(str(data[klic][0] / (data[klic][1] * klic))), 2)
-                mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}")  # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
-                vysledek.append(mezivysledek_carka)
-        return vysledek
+print(dict(sorted(slovnik_data_pro_mal.items())))  # seřazený slovník podle klíčů, pozor na seřazování slovníku - ošemetné, pro zobrazení či tahání infa ale stačí
 
-    vysledek_data = vypocet_mal(slovnik_data_pro_mal)
-    print(vysledek_data)
-    print(segmentovany_text_types)
 
-    # uložení výsledků do tabulky
-    with open(f"data_S_M_F_types_stud_{cislo}.csv", "x", encoding="UTF-8") as csvfile:
-        vysledek_mal = csv.writer(csvfile, delimiter=';', lineterminator='\n')
-        vysledek_mal.writerow(["construct", "frq", "mean of constituent"])
-        for i in vysledek_data:
-            vysledek_mal.writerow([i[0], i[1], i[2]])
+# funkce s výpočtem MALu
+def vypocet_mal(data):
+    vysledek = []
+    for klic in sorted(data):  # tahá ze seřazeného seznamu klíčů, ale nic nepřepisuje !
+        if klic == 0:
+            pass
+        else:
+            prumer = round(Decimal(str(data[klic][0] / (data[klic][1] * klic))), 2)
+            mezivysledek_carka = (klic, data[klic][1], f"{prumer:n}")  # to f"..." dělám proto, aby se převedly korektně desetinné tečky na desetinné čárky
+            vysledek.append(mezivysledek_carka)
+    return vysledek
+
+
+vysledek_data = vypocet_mal(slovnik_data_pro_mal)
+print(vysledek_data)
+print(segmentovany_text_types)
+
+# uložení výsledků do tabulky
+with open("data_S_M_F_types_stud.csv", "x", encoding="UTF-8") as csvfile:
+    vysledek_mal = csv.writer(csvfile, delimiter=';', lineterminator='\n')
+    vysledek_mal.writerow(["construct", "frq", "mean of constituent"])
+    for i in vysledek_data:
+        vysledek_mal.writerow([i[0], i[1], i[2]])


### PR DESCRIPTION
Procházení více souborů byla jen dočasná praktická pomůcka, která již ničemu neslouží. Každý skript nyní zpracovává právě jeden soubor, zatím stále ještě pevně daného jména. Je na uživateli, aby si vstupní soubor připravil, a tak je to správné.

Toto má ještě další zajímavé praktické důsledky:

- Ve skriptech počítajících MAL byly (nesprávně) definice funkcí uvnitř cyklu. Definovaly se při každém průchodu zbytečně ve stejné podobě znova. Odstraněním cyklů se tato chyba opravila.
- Protože Flake8 definice funkcí v cyklech nebere v potaz, vznikla řada nových porušení _E302_ a _E305_. Definice funkcí totiž kolem sebe mají mít vždy dva prázdné řádky.
- Díky prázdným řádků kolem definic funkcí je viditelnější skutečnost, že tyto nejsou na začátku kódu, kam patří. Místo toho se prolínají s přímo vykonávanými částmi skriptu.
- Celkově došlo ke zkrácení řádků o jednu úroveň odsazení. Celkový počet řádků přesahující omezení 79 znaků zůstává stále stejný (31 takových), ale zkrátit je bude nyní snazší.
- Není třeba pro názvy souborů používat formátovací řetězce (`f"řetězec"`). Tím se kód zjednodušil a stal se čitelnějším.