### PR TITLE
♻️ Odstraň funkci porovnani_textu_se_slovnikem

### DIFF
--- a/morfo_segmentace_manuální.py
+++ b/morfo_segmentace_manuální.py
@@ -114,15 +114,9 @@ def ulozeni_substituovaneho_textu(text):
         print(text, file=soubor)
 
 
-def porovnani_textu_se_slovnikem(text_mnozina, obsah_slovniku):
-    # porovnání slov k segmentaci se slovy ve slovníku (zda už některé z nich ve slovníku nejsou segmentované)
-    vysledek_porovnani = list(text_mnozina - obsah_slovniku)
-    print(len(vysledek_porovnani))  # vypíše počet slov, které je třeba nasegmentovat (obvykle neradostné číslo)
-
-    return vysledek_porovnani
-
-
 def segmentace_manualni(slova):
+    print(len(slova))  # vypíše počet slov, které je třeba nasegmentovat (obvykle neradostné číslo)
+
     # segmentace slova + vytváření slovníku
     with open("můj_slovník.csv", "a", encoding="UTF-8") as csvfile:
         vysledek_segmentace = csv.writer(csvfile, delimiter=';', lineterminator='\n')
@@ -139,8 +133,8 @@ def segmentace_manualni(slova):
 # spustím úpravu textu
 text_k_segmentaci_substituovany, text_na_slova_uniq_foneticky = uprava_textu(text_k_segmentaci)
 
-# spustím porovnání s mojim slovníkem
-slova_k_segmentaci = porovnani_textu_se_slovnikem(text_na_slova_uniq_foneticky, slova_ze_slovniku)
+# porovnání slov k segmentaci se slovy ve slovníku (zda už některé z nich ve slovníku nejsou segmentované)
+slova_k_segmentaci = text_na_slova_uniq_foneticky - slova_ze_slovniku
 
 # spustím segmentování samotné (a rozšiřování slovníku, ale je tam chybaaa - anebo není? ověřit, jestli se to fakt zapisuje dobře do toho souboru)
 segmentace_manualni(slova_k_segmentaci)


### PR DESCRIPTION
Funkce [_morfo_segmentace_manuální.porovnani_textu_se_slovnikem_](https://github.com/pelegrinova/morfo_segmentace/blob/4ec52e5ea45f943b58be467ce787eb79ae1fb944/morfo_segmentace_manu%C3%A1ln%C3%AD.py#L117) vůbec není potřeba. Rozdíl dvou množin je triviální operace. Zápis `množina1 - množina2` je srozumitelnější než zavádějící název `porovnání(množina1, množina2)`.

Převod množiny na seznam zcela odebrán. Nebyl potřeba: z množiny lze přímo vytáhnout počet prvků (`len(slova)`), tak je lze procházet cyklem (`for položka in slova`).

Výpis počtu slov přesunut ze zrušené funkce do funkce _segmentace_manualni_. Patří spíše tam, neboť tato funkce komunikuje s uživatelem.