### PR TITLE
Odstraň podtržítka z názvů souborů

### DIFF
--- a/morfo_segmentace_výpočet_malu_tokens.py
+++ b/morfo_segmentace_výpočet_malu_tokens.py
@@ -28,7 +28,7 @@ def vypocet_mal(data):
 setlocale(LC_NUMERIC, "cs_CZ.UTF-8")
 
 # načtení segmentovaného textu
-with open("vysledek_segmentace_stud_.txt", encoding="UTF-8") as soubor:
+with open("vysledek_segmentace_stud.txt", encoding="UTF-8") as soubor:
     segmentovany_text_tokens = soubor.read().strip().split(sep=" ")
 
 # přípravné výpočty
@@ -72,7 +72,7 @@ vysledek_mal = vypocet_mal(slovnik_data_pro_mal)
 print(vysledek_mal)
 
 # uložení výsledků do tabulky
-with open("data_S_M_F_tokens_stud_.csv", "x", encoding="UTF-8") as csvfile:
+with open("data_S_M_F_tokens_stud.csv", "x", encoding="UTF-8") as csvfile:
     vysledek_data = csv.writer(csvfile, delimiter=';', lineterminator='\n')
     vysledek_data.writerow(["construct", "frq", "mean of constituent"])
     for i in vysledek_mal:

--- a/morfo_segmentace_výpočet_malu_types.py
+++ b/morfo_segmentace_výpočet_malu_types.py
@@ -86,7 +86,7 @@ print(vysledek_data)
 print(segmentovany_text_types)
 
 # uložení výsledků do tabulky
-with open("data_S_M_F_types_stud_.csv", "x", encoding="UTF-8") as csvfile:
+with open("data_S_M_F_types_stud.csv", "x", encoding="UTF-8") as csvfile:
     vysledek_mal = csv.writer(csvfile, delimiter=';', lineterminator='\n')
     vysledek_mal.writerow(["construct", "frq", "mean of constituent"])
     for i in vysledek_data:


### PR DESCRIPTION
Vyřešení konfliktů dec3758 bylo nedůsledné: došlo ke změně názvů některých souborů. Vráceno do podoby v a39fa81.

Navazuje na #12.