### PR TITLE
🗑 Odstraň zbytečný pass

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -22,7 +22,6 @@ for i in range(len(slova_k_segmentaci)):
         slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
     except KeyError:
         print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
-        pass   #
 
 text_segmentovany_slouceny = " ".join(slova_k_segmentaci)
 


### PR DESCRIPTION
Klíčové slovo pass je potřeba pouze tam, kde blok kódu neobsahuje žádné jiné tělo.

Efektivně nahrazuje #20.