### PR TITLE
Odděl seznamy slov v segmentaci

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -17,14 +17,16 @@ with open("foneticky_přepsaný_stud.txt", encoding="UTF-8") as soubor:
     slova_k_segmentaci = soubor.read().strip().split(sep=" ")
 
 # autosegmentace
-for i in range(len(slova_k_segmentaci)):
+segmented_words = []
+for original_word in slova_k_segmentaci:
     try:
-        slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
+        segmented_word = slovnik[original_word]
     except KeyError:
-        print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
-        pass   #
+        print(f"POZOR! SLOVO {original_word} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
+        segmented_word = original_word
+    segmented_words.append(segmented_word)
 
-text_segmentovany_slouceny = " ".join(slova_k_segmentaci)
+text_segmentovany_slouceny = " ".join(segmented_words)
 
 # uložení výsledku segmentace do souboru
 with open("vysledek_segmentace_stud.txt", mode="x", encoding="UTF-8") as soubor:


### PR DESCRIPTION
Původní text k segmentaci rozdělený na slova je jinou logickou jednotkou než seznam segmentovaných slov dohledaných dle slovníku. Rozdělením na dva seznamy nedochází k přepisování segmentovaných slov a přeskakování nesegmentovatelných pozic. Kód je nyní popisnější.