### PR TITLE
🎨 Rozděl dlouhý řetězec na více řádků

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -21,7 +21,10 @@ for i in range(len(slova_k_segmentaci)):
     try:
         slova_k_segmentaci[i] = slovnik[slova_k_segmentaci[i]]
     except KeyError:
-        print(f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ NEBUDE SEGMENTOVÁNO!")
+        print(
+            f"POZOR! SLOVO {slova_k_segmentaci[i]} CHYBÍ VE SLOVNÍKU A TUDÍŽ"
+            "NEBUDE SEGMENTOVÁNO!"
+        )
         pass   #
 
 text_segmentovany_slouceny = " ".join(slova_k_segmentaci)


### PR DESCRIPTION
Dlouhý řetězec varování rozdělen, aby nevytvářel řádky delší než 79 znaků podle [PEP 8](https://www.python.org/dev/peps/pep-0008/).