### PR TITLE
Sjednoť mód výstupních souborů

### DIFF
--- a/morfo_segmentace_manuální.py
+++ b/morfo_segmentace_manuální.py
@@ -95,7 +95,7 @@ def uprava_textu(text):
 
 def ulozeni_substituovaneho_textu(text):
     # uložení "foneticky" upraveného textu
-    with open("foneticky_přepsané_něco.txt", mode="w", encoding="UTF-8") as soubor:
+    with open("foneticky_přepsané_něco.txt", mode="x", encoding="UTF-8") as soubor:
         print(text, file=soubor)
 
 


### PR DESCRIPTION
Pro všechny zapisované výstupní soubory (tedy ne slovník) se používá mód _x_. Jediné místo, kde se používalo _w_ nahrazeno.