### PR TITLE
Zjednoduš načítání souboru k autosegmentaci

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -14,7 +14,7 @@ with open(DICTIONARY_FILE, encoding="UTF-8") as soubor:
 
 # načtení textu/slov k segmentaci (a odstranění případné mezery na konci)
 with open(INPUT_FILE, encoding="UTF-8") as soubor:
-    slova_k_segmentaci = soubor.read().strip().split(sep=" ")
+    slova_k_segmentaci = soubor.read().split()
 
 # autosegmentace
 segmented_words = []


### PR DESCRIPTION
Použití `split()` místo `split(sep=" ")` umožní vynechat `strip()`.

K tomuto bych měl drobnou výhradu. Vstupem automatické segmentace je předchroupaný soubor známého formátu. Víme, že obsahuje právě jeden řádek a na tomto jsou slova oddělená právě jednou mezerou. Proto odstranění koncového nového řádku a následné rozdělení po jedné mezeře je velmi přesné a efektivní zpravování. 👍🏻 V takovém případě bych však nahradil `strip()` za `rstrip()`, neboť potřebujeme odstranit pouze koncový nový řádek textového souboru vědouce, že na začátku souboru se žádný bílý znak nacházet nemůže.

Výhodou navrženého `split()` bez `strip()` je naopak to, že je to kratší a teoreticky čitelnější. Pro počítač spíše náročnější a ne tolik sémantické. Vytvořil jsem proto ještě alternativní #34 a zvol si, co se ti líbí více.