### PR TITLE
Zpřesni načítání souboru k autosegmentaci

### DIFF
--- a/morfo_segmentace_automatická.py
+++ b/morfo_segmentace_automatická.py
@@ -14,7 +14,7 @@ with open(DICTIONARY_FILE, encoding="UTF-8") as soubor:
 
 # načtení textu/slov k segmentaci (a odstranění případné mezery na konci)
 with open(INPUT_FILE, encoding="UTF-8") as soubor:
-    slova_k_segmentaci = soubor.read().strip().split(sep=" ")
+    slova_k_segmentaci = soubor.read().rstrip().split(sep=" ")
 
 # autosegmentace
 segmented_words = []


### PR DESCRIPTION
Použití `rstrip()` místo `strip()` více vystihuje formát načítaného souboru. Odstraňujeme nový řádek z konce, neboť se jedná o textový soubor o jednom řádku. Zato víme, že na začátku souboru žádný bílý znak být nemůže.

Možná náhrada za #33, za mě asi sémantičtější. Trochu více k tomu v odkázané žádosti. Vyber si, která se ti líbí víc.